### PR TITLE
Avoid interpreting % in command-not-found output

### DIFF
--- a/eshell-command-not-found.el
+++ b/eshell-command-not-found.el
@@ -63,11 +63,11 @@
 (defun eshell-command-not-found (command)
   "Hook to run command-not-found script in eshell.
 Argument COMMAND is the not found command."
-  (error (string-trim-right
-          (shell-command-to-string
-           (format "%s %s"
-                   eshell-command-not-found-command
-                   (shell-quote-argument command))))))
+  (error "%s" (string-trim-right
+               (shell-command-to-string
+                (format "%s %s"
+                        eshell-command-not-found-command
+                        (shell-quote-argument command))))))
 
 ;;;###autoload
 (define-minor-mode eshell-command-not-found-mode


### PR DESCRIPTION
`(error ...)` takes a format-string, so it'll interpret any `%` in the output of the "command-not-found" command as format specifiers.